### PR TITLE
Re-implement approval hook API

### DIFF
--- a/approve_or_deny.sh
+++ b/approve_or_deny.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 # We expect to receive: <zone name> <zone serial> <approval token>
 set -euo pipefail -x
 
-echo "Hook invoked with $@"
+echo "Hook invoked with $*"
 
 ZONE_NAME="$1"
 ZONE_SERIAL="$2"
 APPROVAL_TOKEN="$3"
 
-wget -qO- "http://127.0.0.1:8080/rs/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+wget -qO- "http://127.0.0.1:8950/_unit/rs/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"

--- a/approve_or_deny_signed.sh
+++ b/approve_or_deny_signed.sh
@@ -1,16 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 # We expect to receive: <zone name> <zone serial> <approval token>
 set -euo pipefail -x
 
-echo "Hook invoked with $@"
+echo "Hook invoked with $*"
 
 ZONE_NAME="$1"
 ZONE_SERIAL="$2"
 APPROVAL_TOKEN="$3"
 
-dig +noall +onesoa +answer @127.0.0.1 -p 8057 ${ZONE_NAME} AXFR | dnssec-verify -o ${ZONE_NAME} /dev/stdin /tmp/keys/ || {
-    wget -qO- "http://127.0.0.1:8080/rs2/reject/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+dig +noall +onesoa +answer @127.0.0.1 -p 8057 "${ZONE_NAME}" AXFR | dnssec-verify -o "${ZONE_NAME}" /dev/stdin /tmp/keys/ || {
+    wget -qO- "http://127.0.0.1:8950/_unit/rs2/reject/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
     exit 0
 }
 
-wget -qO- "http://127.0.0.1:8080/rs2/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"
+wget -qO- "http://127.0.0.1:8950/_unit/rs2/approve/${APPROVAL_TOKEN}?zone=${ZONE_NAME}&serial=${ZONE_SERIAL}"

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 use reqwest::{Method, RequestBuilder};
 
 const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(120);
-static APP_USER_AGENT: &str =
-    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 pub struct NameshedApiClient {
     base_uri: String,

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -37,10 +37,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(
-        self,
-        client: NameshedApiClient,
-    ) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
         match self {
             Self::Zone(zone) => zone.execute(client).await,
             Self::Status(status) => status.execute(client).await,

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -30,10 +30,7 @@ pub enum StatusCommand {
 //   - maybe have it both on server level status command (so here) and in the zone command?
 
 impl Status {
-    pub async fn execute(
-        self,
-        client: NameshedApiClient,
-    ) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
         match self.command {
             Some(StatusCommand::Zone { name }) => {
                 // TODO: move to function that can be called by the general

--- a/src/cli/commands/zone.rs
+++ b/src/cli/commands/zone.rs
@@ -3,10 +3,7 @@ use domain::base::Name;
 use futures::TryFutureExt;
 use log::error;
 
-use crate::api::{
-    ZoneRegister, ZoneRegisterResult, ZoneSource, ZoneStatusResult,
-    ZonesListResult,
-};
+use crate::api::{ZoneRegister, ZoneRegisterResult, ZoneSource, ZoneStatusResult, ZonesListResult};
 use crate::cli::client::NameshedApiClient;
 use crate::log::ExitError;
 
@@ -56,10 +53,7 @@ pub enum ZoneCommand {
 // - reload zone (i.e. from file)
 
 impl Zone {
-    pub async fn execute(
-        self,
-        client: NameshedApiClient,
-    ) -> Result<(), ExitError> {
+    pub async fn execute(self, client: NameshedApiClient) -> Result<(), ExitError> {
         match self.command {
             ZoneCommand::Register { name, source } => {
                 let res: ZoneRegisterResult = client
@@ -116,10 +110,7 @@ impl Zone {
                         ExitError
                     })?;
 
-                println!(
-                    "Success: Sent zone reload command for {}",
-                    response.name
-                );
+                println!("Success: Sent zone reload command for {}", response.name);
             }
         }
         Ok(())

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,4 +1,4 @@
 #[derive(Clone, Debug)]
 pub struct CliError {
-    msg: String
+    msg: String,
 }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -68,6 +68,7 @@
 use domain::base::Serial;
 use domain::zonetree::StoredName;
 use std::fmt::{self, Debug};
+use tokio::sync::mpsc;
 
 //------------ GraphMetrics --------------------------------------------------
 pub trait GraphStatus: Send + Sync {
@@ -128,6 +129,16 @@ pub struct Terminated;
 #[derive(Clone, Debug)]
 pub enum ApplicationCommand {
     Terminate,
+    HandleZoneReviewApi {
+        zone_name: StoredName,
+        zone_serial: Serial,
+        approval_token: String,
+        operation: String,
+        http_tx: mpsc::Sender<Result<(), ()>>,
+    },
+    HandleZoneReviewApiStatus {
+        http_tx: mpsc::Sender<String>,
+    },
     SeekApprovalForUnsignedZone {
         zone_name: StoredName,
         zone_serial: Serial,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -519,8 +519,7 @@ impl Manager {
                         "example.com".into(),
                         "127.0.0.1:8055 KEY sec1-key".into(),
                     )]),
-                    // Temporarily disable hooks as the required HTTP functionality has been removed pending replacement.
-                    hooks: vec![], // vec![String::from("/tmp/approve_or_deny.sh")],
+                    hooks: vec![String::from("/tmp/approve_or_deny.sh")],
                     mode: zone_server::Mode::Prepublish,
                     source: zone_server::Source::UnsignedZones,
                     update_tx: update_tx.clone(),
@@ -563,8 +562,7 @@ impl Manager {
                         "example.com".into(),
                         "127.0.0.1:8055 KEY sec1-key".into(),
                     )]),
-                    // Temporarily disable hooks as the required HTTP functionality has been removed pending replacement.
-                    hooks: vec![], // vec![String::from("/tmp/approve_or_deny_signed.sh")],
+                    hooks: vec![String::from("/tmp/approve_or_deny_signed.sh")],
                     mode: zone_server::Mode::Prepublish,
                     source: zone_server::Source::SignedZones,
                     update_tx: update_tx.clone(),

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -524,6 +524,7 @@ impl Manager {
                     source: zone_server::Source::UnsignedZones,
                     update_tx: update_tx.clone(),
                     cmd_rx: rs_rx,
+                    http_api_path: Arc::new(String::from("/_unit/rs/")),
                 }),
             ),
             (
@@ -554,6 +555,7 @@ impl Manager {
             (
                 String::from("RS2"),
                 Unit::ZoneServer(ZoneServerUnit {
+                    http_api_path: Arc::new(String::from("/_unit/rs2/")),
                     listen: vec![
                         "tcp:127.0.0.1:8057".parse().unwrap(),
                         "udp:127.0.0.1:8057".parse().unwrap(),
@@ -572,6 +574,7 @@ impl Manager {
             (
                 String::from("PS"),
                 Unit::ZoneServer(ZoneServerUnit {
+                    http_api_path: Arc::new(String::from("/_unit/ps/")),
                     listen: vec![
                         "tcp:127.0.0.1:8058".parse().unwrap(),
                         "udp:127.0.0.1:8058".parse().unwrap(),

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -111,8 +111,8 @@ impl HttpServer {
             .route("/rs/{action}/{token}", get(Self::handle_rs))
             .route("/rs2/", get(Self::handle_rs2_base))
             .route("/rs2/{action}/{token}", get(Self::handle_rs2));
-            // .route("/zl/", get(Self::handle_zl_base))
-            // .route("/zs/", get(Self::handle_zs_base));
+        // .route("/zl/", get(Self::handle_zl_base))
+        // .route("/zs/", get(Self::handle_zs_base));
 
         let app = Router::new()
             .route("/", get(|| async { "Hello, World!" }))
@@ -266,7 +266,6 @@ impl HttpServer {
     ) -> Result<(), StatusCode> {
         Self::zone_server_unit_api_common("RS", uri, state, action, token, params).await
     }
-
 
     //--- common api implementations
     async fn zone_server_unit_api_base_common(

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::io;
@@ -9,15 +11,22 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use axum::extract;
+use axum::extract::OriginalUri;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::http::Uri;
+use axum::response::Html;
 use axum::routing::get;
 use axum::routing::post;
 use axum::Json;
 use axum::Router;
 use bytes::Bytes;
 use domain::base::Name;
+use domain::base::Serial;
 use domain::zonetree::StoredName;
+use log::warn;
 use log::{debug, error, info};
 use serde::Deserialize;
 use tokio::net::TcpListener;
@@ -45,9 +54,13 @@ pub struct HttpServer {
     pub cmd_rx: Option<mpsc::Receiver<ApplicationCommand>>,
 }
 
+struct HttpServerState {
+    pub component: Component,
+}
+
 impl HttpServer {
     pub async fn run(mut self, component: Component) -> Result<(), Terminated> {
-        let _component = Arc::new(RwLock::new(component));
+        // let _component = Arc::new(RwLock::new(component));
         // Setup listener
         let sock = TcpListener::bind(self.listen_addr).await.map_err(|e| {
             error!("[{HTTP_UNIT_NAME}]: {}", e);
@@ -75,10 +88,35 @@ impl HttpServer {
             }
         });
 
-        let state = Arc::new(self);
+        let state = Arc::new(HttpServerState { component });
+
+        // For now, only implemented the ZoneReviewApi for the Units:
+        // "RS"   ZoneServerUnit
+        // "RS2"  ZoneServerUnit
+        // "PS"   ZoneServerUnit
+        //
+        // Skipping SigningHistoryApi and ZoneListApi's for
+        // "ZL"   ZoneLoader
+        // "ZS"   ZoneSignerUnit
+        // "CC"   CentralCommand
+        //
+        // Noting them down, but without a previously existing API:
+        // "HS"   HttpServer
+        // "KM"   KeyManagerUnit
+
+        let unit_router = Router::new()
+            .route("/ps/", get(Self::handle_ps_base))
+            .route("/ps/{action}/{token}", get(Self::handle_ps))
+            .route("/rs/", get(Self::handle_rs_base))
+            .route("/rs/{action}/{token}", get(Self::handle_rs))
+            .route("/rs2/", get(Self::handle_rs2_base))
+            .route("/rs2/{action}/{token}", get(Self::handle_rs2));
+            // .route("/zl/", get(Self::handle_zl_base))
+            // .route("/zs/", get(Self::handle_zs_base));
 
         let app = Router::new()
             .route("/", get(|| async { "Hello, World!" }))
+            .nest("/_unit", unit_router)
             .route("/status", get(Self::status))
             .route("/zones/list", get(Self::zones_list))
             .route("/zone/register", post(Self::zone_register))
@@ -91,19 +129,14 @@ impl HttpServer {
         })
     }
 
-    async fn zone_register(
-        Json(payload): Json<ZoneRegister>,
-    ) -> Json<ZoneRegisterResult> {
+    async fn zone_register(Json(payload): Json<ZoneRegister>) -> Json<ZoneRegisterResult> {
         Json(ZoneRegisterResult {
             name: payload.name.clone(),
             status: "Maybe Success".into(),
         })
     }
 
-    async fn zones_list(
-        // TODO: replace HttpServer with slimmed down state struct?
-        State(_state): State<Arc<HttpServer>>,
-    ) -> Json<ZonesListResult> {
+    async fn zones_list(State(_state): State<Arc<HttpServerState>>) -> Json<ZonesListResult> {
         // let zones = state
         //     .zones
         //     .list()
@@ -128,22 +161,210 @@ impl HttpServer {
         //     })
         //     .collect();
         // Json(ZonesListResult { zones })
-        Json(ZonesListResult { zones: Vec::default() })
+        Json(ZonesListResult {
+            zones: Vec::default(),
+        })
     }
 
-    async fn zone_status(
-        Path(name): Path<Name<Bytes>>,
-    ) -> Json<ZoneStatusResult> {
+    async fn zone_status(Path(name): Path<Name<Bytes>>) -> Json<ZoneStatusResult> {
         Json(ZoneStatusResult { name })
     }
 
-    async fn zone_reload(
-        Path(name): Path<Name<Bytes>>,
-    ) -> Json<ZoneReloadResult> {
+    async fn zone_reload(Path(name): Path<Name<Bytes>>) -> Json<ZoneReloadResult> {
         Json(ZoneReloadResult { name })
     }
 
     async fn status() -> Json<ServerStatusResult> {
         Json(ServerStatusResult {})
+    }
+}
+
+//------------ HttpServer Handler for /<unit>/ -------------------------------
+
+impl HttpServer {
+    //--- /ps/
+    async fn handle_ps_base(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+    ) -> Result<Html<String>, StatusCode> {
+        Self::zone_server_unit_api_base_common("PS", uri, state).await
+    }
+
+    async fn handle_ps(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+        Path((action, token)): Path<(String, String)>,
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Result<(), StatusCode> {
+        Self::zone_server_unit_api_common("PS", uri, state, action, token, params).await
+    }
+
+    // //--- /zs/
+    // async fn handle_zs_base(
+    //     uri: OriginalUri,
+    //     State(state): State<Arc<HttpServerState>>,
+    // ) -> Result<Html<String>, StatusCode> {
+    //     Self::zone_server_unit_api_base_common("ZS", uri, state).await
+    // }
+
+    // async fn handle_zs(
+    //     uri: OriginalUri,
+    //     State(state): State<Arc<HttpServerState>>,
+    //     Path((action, token)): Path<(String, String)>,
+    //     Query(params): Query<HashMap<String, String>>,
+    // ) -> Result<(), StatusCode> {
+    //     Self::zone_server_unit_api_common("ZS", uri, state, action, token, params).await
+    // }
+
+    // //--- /zl/
+    // async fn handle_zl_base(
+    //     uri: OriginalUri,
+    //     State(state): State<Arc<HttpServerState>>,
+    // ) -> Result<Html<String>, StatusCode> {
+    //     Self::zone_server_unit_api_base_common("ZL", uri, state).await
+    // }
+
+    // async fn handle_zl(
+    //     uri: OriginalUri,
+    //     State(state): State<Arc<HttpServerState>>,
+    //     Path((action, token)): Path<(String, String)>,
+    //     Query(params): Query<HashMap<String, String>>,
+    // ) -> Result<(), StatusCode> {
+    //     Self::zone_server_unit_api_common("ZL", uri, state, action, token, params).await
+    // }
+
+    //--- /rs2/
+    async fn handle_rs2_base(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+    ) -> Result<Html<String>, StatusCode> {
+        Self::zone_server_unit_api_base_common("RS2", uri, state).await
+    }
+
+    async fn handle_rs2(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+        Path((action, token)): Path<(String, String)>,
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Result<(), StatusCode> {
+        Self::zone_server_unit_api_common("RS2", uri, state, action, token, params).await
+    }
+
+    //--- /rs/
+    async fn handle_rs_base(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+    ) -> Result<Html<String>, StatusCode> {
+        Self::zone_server_unit_api_base_common("RS", uri, state).await
+    }
+
+    async fn handle_rs(
+        uri: OriginalUri,
+        State(state): State<Arc<HttpServerState>>,
+        Path((action, token)): Path<(String, String)>,
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Result<(), StatusCode> {
+        Self::zone_server_unit_api_common("RS", uri, state, action, token, params).await
+    }
+
+
+    //--- common api implementations
+    async fn zone_server_unit_api_base_common(
+        unit: &str,
+        uri: OriginalUri,
+        state: Arc<HttpServerState>,
+    ) -> Result<Html<String>, StatusCode> {
+        let (tx, mut rx) = mpsc::channel(10);
+        state
+            .component
+            .send_command(
+                unit,
+                ApplicationCommand::HandleZoneReviewApiStatus { http_tx: tx },
+            )
+            .await;
+
+        let res = rx.recv().await;
+        let Some(res) = res else {
+            // Failed to receive response... When would that happen?
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        };
+
+        debug!(
+            "[{HTTP_UNIT_NAME}]: Handled HTTP request: {}",
+            uri.path_and_query()
+                .map(|p| { p.as_str() })
+                .unwrap_or_default()
+        );
+
+        Ok(Html(res))
+    }
+
+    // All ZoneServerUnit's have the same review API
+    //
+    // API: GET /{approve,reject}/<approval token>?zone=<zone name>&serial=<zone serial>
+    //
+    // NOTE: We use query parameters for the zone details because dots that appear in zone names
+    // are decoded specially by HTTP standards compliant libraries, especially occurences of
+    // handling of /./ are problematic as that gets collapsed to /.
+    async fn zone_server_unit_api_common(
+        unit: &str,
+        uri: OriginalUri,
+        state: Arc<HttpServerState>,
+        action: String,
+        token: String,
+        params: HashMap<String, String>,
+    ) -> Result<(), StatusCode> {
+        let uri = uri.path_and_query().map(|p| p.as_str()).unwrap_or_default();
+        let zone_name = params.get("zone");
+        let zone_serial = params.get("serial");
+        if matches!(action.as_ref(), "approve" | "reject")
+            && zone_name.is_some()
+            && zone_serial.is_some()
+            && token.len() > 0
+        {
+            let zone_name = zone_name.unwrap();
+            let zone_serial = zone_serial.unwrap();
+
+            if let Ok(zone_name) = Name::<Bytes>::from_str(zone_name) {
+                if let Ok(zone_serial) = Serial::from_str(zone_serial) {
+                    let (tx, mut rx) = mpsc::channel(10);
+                    state
+                        .component
+                        .send_command(
+                            unit,
+                            ApplicationCommand::HandleZoneReviewApi {
+                                zone_name,
+                                zone_serial,
+                                approval_token: token,
+                                operation: action,
+                                http_tx: tx,
+                            },
+                        )
+                        .await;
+
+                    let res = rx.recv().await;
+                    let Some(res) = res else {
+                        // Failed to receive response... When would that happen?
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    };
+
+                    let ret = match res {
+                        Ok(_) => Ok(()),
+                        Err(_) => Err(StatusCode::BAD_REQUEST),
+                    };
+                    // TODO: make debug when setting log level is fixed
+                    warn!("[{HTTP_UNIT_NAME}]: Handled HTTP request: {uri} :: {ret:?}");
+                    // debug!("[{HTTP_UNIT_NAME}]: Handled HTTP request: {uri} :: {ret:?}");
+
+                    return ret;
+                } else {
+                    warn!("[{HTTP_UNIT_NAME}]: Invalid zone serial '{zone_serial}' in request.");
+                }
+            } else {
+                warn!("[{HTTP_UNIT_NAME}]: Invalid zone name '{zone_name}' in request.");
+            }
+        }
+        warn!("[{HTTP_UNIT_NAME}]: Invalid HTTP request: {uri}");
+        Err(StatusCode::BAD_REQUEST)
     }
 }

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -324,19 +324,6 @@ impl ZoneServer {
                                 continue;
                             }
 
-                            if arc_self.hooks.is_empty() {
-                                // Approve immediately.
-                                match arc_self.source {
-                                    Source::UnsignedZones => {
-                                        update_tx.send(Update::UnsignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).await.unwrap();
-                                    }
-                                    Source::SignedZones => {
-                                        update_tx.send(Update::SignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).await.unwrap();
-                                    }
-                                    Source::PublishedZones => unreachable!(),
-                                }
-                            }
-
                             info!("[{unit_name}]: Seeking approval for {zone_type} zone '{zone_name}' at serial {zone_serial}.");
                             for hook in &arc_self.hooks {
                                 let approval_token = Uuid::new_v4();

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -113,6 +113,9 @@ pub enum Source {
 
 #[derive(Debug)]
 pub struct ZoneServerUnit {
+    /// The relative path at which we should listen for HTTP query API requests
+    pub http_api_path: Arc<String>,
+
     /// Addresses and protocols to listen on.
     pub listen: Vec<ListenAddr>,
 
@@ -184,6 +187,7 @@ impl ZoneServerUnit {
 
         ZoneServer::new(
             component,
+            self.http_api_path,
             self.mode,
             self.source,
             self.hooks,
@@ -239,22 +243,25 @@ impl ZoneServerUnit {
 //------------ ZoneServer ----------------------------------------------------
 
 struct ZoneServer {
+    http_api_path: Arc<String>,
+    zone_review_api: Option<ZoneReviewApi>,
     component: Arc<RwLock<Component>>,
-    _mode: Mode,
+    mode: Mode,
     source: Source,
     hooks: Vec<String>,
-    _listen: Vec<ListenAddr>,
+    listen: Vec<ListenAddr>,
     #[allow(clippy::type_complexity)]
     pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
     #[allow(clippy::type_complexity)]
     last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
-    _zones: XfrDataProvidingZonesWrapper,
+    zones: XfrDataProvidingZonesWrapper,
 }
 
 impl ZoneServer {
     #[allow(clippy::too_many_arguments)]
     fn new(
         component: Arc<RwLock<Component>>,
+        http_api_path: Arc<String>,
         mode: Mode,
         source: Source,
         hooks: Vec<String>,
@@ -262,24 +269,37 @@ impl ZoneServer {
         zones: XfrDataProvidingZonesWrapper,
     ) -> Self {
         Self {
+            zone_review_api: Default::default(),
+            http_api_path,
             component,
-            _mode: mode,
+            mode,
             source,
             hooks,
             pending_approvals: Default::default(),
             last_approvals: Default::default(),
-            _listen: listen,
-            _zones: zones,
+            listen,
+            zones,
         }
     }
 
     async fn run(
-        self,
+        mut self,
         unit_name: &str,
         update_tx: mpsc::Sender<Update>,
         mut cmd_rx: mpsc::Receiver<ApplicationCommand>,
     ) -> Result<(), crate::comms::Terminated> {
         // let status_reporter = self.status_reporter.clone();
+
+        // Setup approval API endpoint
+        self.zone_review_api = Some(ZoneReviewApi::new(
+            update_tx.clone(),
+            self.pending_approvals.clone(),
+            self.last_approvals.clone(),
+            self.zones.clone(),
+            self.mode,
+            self.source,
+            self.listen.clone(),
+        ));
 
         let arc_self = Arc::new(self);
 
@@ -298,6 +318,45 @@ impl ZoneServer {
                         ApplicationCommand::Terminate => {
                             // arc_self.status_reporter.terminated();
                             return Err(Terminated);
+                        }
+
+                        ApplicationCommand::HandleZoneReviewApi {
+                            zone_name,
+                            zone_serial,
+                            approval_token,
+                            operation,
+                            http_tx,
+                        } => {
+                            http_tx
+                                .send(
+                                    arc_self
+                                        .zone_review_api
+                                        .as_ref()
+                                        .expect("This should have been setup on startup.")
+                                        .process_request(
+                                            zone_name.clone(),
+                                            zone_serial.clone(),
+                                            approval_token,
+                                            operation,
+                                        )
+                                    .await,
+                                )
+                                .await
+                                .expect("TODO: Should this always succeed?");
+                        }
+
+                        ApplicationCommand::HandleZoneReviewApiStatus { http_tx } => {
+                            http_tx
+                                .send(
+                                    arc_self
+                                        .zone_review_api
+                                        .as_ref()
+                                        .expect("This should have been setup on startup.")
+                                        .build_status_response()
+                                        .await,
+                                )
+                                .await
+                                .expect("TODO: Should this always succeed?");
                         }
 
                         ApplicationCommand::SeekApprovalForUnsignedZone {
@@ -344,6 +403,8 @@ impl ZoneServer {
                                 {
                                     Ok(_) => {
                                         info!("[{unit_name}]: Executed hook '{hook}' for {zone_type} zone '{zone_name}' at serial {zone_serial}");
+                                        info!("[{unit_name}]: Confirm with HTTP GET {}approve/{approval_token}?zone={zone_name}&serial={zone_serial}", arc_self.http_api_path);
+                                        info!("[{unit_name}]: Reject with HTTP GET {}reject/{approval_token}?zone={zone_name}&serial={zone_serial}", arc_self.http_api_path);
                                     }
                                     Err(err) => {
                                         error!(
@@ -521,4 +582,208 @@ fn zone_server_service(
     let builder = mk_builder_for_target();
     let additional = answer.to_message(request.message(), builder);
     Ok(CallResult::new(additional))
+}
+
+// TODO: Should we expire old pending approvals, e.g. a hook script failed and
+// they never got approved or rejected?
+impl ZoneReviewApi {
+    async fn process_request(
+        &self,
+        zone_name: Name<Bytes>,
+        zone_serial: Serial,
+        given_approval_token: &str,
+        operation: &str,
+    ) -> Result<(), ()> {
+        let mut status = Err(());
+        let mut remove_approvals = false;
+
+        // Are approvals pending for this serial of this zone?
+        if let Some(pending_approvals) = self
+            .pending_approvals
+            .write()
+            .await
+            .get_mut(&(zone_name.clone(), zone_serial))
+        {
+            // Is this a valid approval token?
+            if let Ok(given_uuid) = Uuid::from_str(given_approval_token) {
+                if let Some(idx) = pending_approvals
+                    .iter()
+                    .position(|&uuid| uuid == given_uuid)
+                {
+                    // For a rejection remove all pending approvals for the zone.
+                    // For an approval remove only the specified approval.
+                    match operation {
+                        "approve" => {
+                            status = Ok(());
+                            pending_approvals.remove(idx);
+
+                            if pending_approvals.is_empty() {
+                                let evt_zone_name = zone_name.clone();
+                                let (zone_type, event) = match self.source {
+                                    Source::UnsignedZones => (
+                                        "unsigned",
+                                        Update::UnsignedZoneApprovedEvent {
+                                            zone_name: evt_zone_name,
+                                            zone_serial,
+                                        },
+                                    ),
+                                    Source::SignedZones => (
+                                        "signed",
+                                        Update::SignedZoneApprovedEvent {
+                                            zone_name: evt_zone_name,
+                                            zone_serial,
+                                        },
+                                    ),
+                                    Source::PublishedZones => unreachable!(),
+                                };
+                                info!("Pending {zone_type} zone '{zone_name}' approved at serial {zone_serial}.");
+                                let approved_at = Instant::now();
+                                self.last_approvals
+                                    .write()
+                                    .await
+                                    .entry((zone_name.clone(), zone_serial))
+                                    .and_modify(|instant| *instant = approved_at)
+                                    .or_insert(approved_at);
+                                self.update_tx.send(event).await.unwrap();
+                                remove_approvals = true;
+                            }
+                        }
+                        "reject" => {
+                            info!("Pending zone '{zone_name}' rejected at serial {zone_serial}.");
+                            status = Ok(());
+                            remove_approvals = true;
+                        }
+                        _ => unreachable!(),
+                    }
+                } else {
+                    warn!("No pending approval found for zone name '{zone_name}' at serial {zone_serial} with approval token '{given_uuid}'.");
+                }
+            } else {
+                warn!("Invalid approval token '{given_approval_token}' in request.");
+            }
+        } else {
+            debug!("No pending approvals for zone name '{zone_name}' at serial {zone_serial}.");
+        }
+
+        if remove_approvals {
+            self.pending_approvals
+                .write()
+                .await
+                .remove(&(zone_name, zone_serial));
+        }
+
+        status
+    }
+}
+
+//------------ ZoneReviewApi -------------------------------------------------
+
+struct ZoneReviewApi {
+    update_tx: mpsc::Sender<Update>,
+    #[allow(clippy::type_complexity)]
+    pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
+    last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
+    zones: XfrDataProvidingZonesWrapper,
+    mode: Mode,
+    source: Source,
+    listen: Vec<ListenAddr>,
+}
+
+impl ZoneReviewApi {
+    #[allow(clippy::type_complexity)]
+    fn new(
+        update_tx: mpsc::Sender<Update>,
+        pending_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Vec<Uuid>>>>,
+        last_approvals: Arc<RwLock<HashMap<(Name<Bytes>, Serial), Instant>>>,
+        zones: XfrDataProvidingZonesWrapper,
+        mode: Mode,
+        source: Source,
+        listen: Vec<ListenAddr>,
+    ) -> Self {
+        Self {
+            update_tx,
+            pending_approvals,
+            last_approvals,
+            zones,
+            mode,
+            source,
+            listen,
+        }
+    }
+}
+
+impl ZoneReviewApi {
+    pub async fn build_status_response(&self) -> String {
+        let mut response_body = self.build_response_header().await;
+
+        self.build_status_response_body(&mut response_body).await;
+
+        self.build_response_footer(&mut response_body);
+
+        response_body
+    }
+
+    async fn build_response_header(&self) -> String {
+        let intro = match (self.mode, self.source) {
+            (Mode::Prepublish, Source::UnsignedZones) => {
+                "Pre-publication review server for unsigned zones"
+            }
+            (Mode::Prepublish, Source::SignedZones) => {
+                "Pre-publication review server for signed zones"
+            }
+            (Mode::Prepublish, Source::PublishedZones) => {
+                "Pre-publication review server for published zones"
+            }
+            (Mode::Publish, Source::UnsignedZones) => "Publication server for unsigned zones",
+            (Mode::Publish, Source::SignedZones) => "Publication server for signed zones",
+            (Mode::Publish, Source::PublishedZones) => "Publication server for published zones",
+        };
+
+        formatdoc! {
+            r#"
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                  <meta charset="UTF-8">
+                </head>
+                <body>
+                <pre>{intro}
+
+            "#,
+        }
+    }
+
+    async fn build_status_response_body(&self, response_body: &mut String) {
+        let num_zones = self.zones.zones.load().iter_zones().count();
+        response_body.push_str(&format!("Serving {num_zones} zones on:\n"));
+
+        for addr in &self.listen {
+            response_body.push_str(&format!("  - {addr}\n"));
+        }
+        response_body.push('\n');
+
+        for zone in self.zones.zones.load().iter_zones() {
+            response_body.push_str(&format!("zone:   {}\n", zone.apex_name()));
+            if self.mode == Mode::Prepublish {
+                for ((_zone_name, zone_serial), pending_approvals) in self
+                    .pending_approvals
+                    .read()
+                    .await
+                    .iter()
+                    .filter(|((zone_name, _), _)| zone_name == zone.apex_name())
+                {
+                    response_body.push_str(&format!(
+                        "        pending approvals for serial {zone_serial}: {}\n",
+                        pending_approvals.len()
+                    ));
+                }
+            }
+        }
+    }
+
+    fn build_response_footer(&self, response_body: &mut String) {
+        response_body.push_str("    </pre>\n");
+        response_body.push_str("  </body>\n");
+        response_body.push_str("</html>\n");
+    }
 }


### PR DESCRIPTION
I copied the ZoneReviewApi code from before the removal, moved all HTTP related stuff into the HTTP server, and used mpsc channels to send the data back.