### PR TITLE
Use unbounded MPSC channels everywhere

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> ExitCode {
         };
 
         // Shut down Nameshed.
-        manager.terminate();
+        manager.terminate().await;
         result
     })
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,6 @@ use log::{debug, info};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::common::file_io::TheFileIo;
@@ -130,28 +129,28 @@ impl Display for TargetCommand {
 /// `Handle::enter()`).
 pub struct Manager {
     /// Commands for the zone loader.
-    loader_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    loader_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the review server.
-    review_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    review_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the key manager.
-    key_manager_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    key_manager_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the zone signer.
-    signer_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    signer_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the secondary review server.
-    review2_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    review2_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the publish server.
-    publish_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    publish_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// Commands for the central command.
-    center_tx: Option<mpsc::Sender<TargetCommand>>,
+    center_tx: Option<mpsc::UnboundedSender<TargetCommand>>,
 
     /// Commands for the http server.
-    http_tx: Option<mpsc::Sender<ApplicationCommand>>,
+    http_tx: Option<mpsc::UnboundedSender<ApplicationCommand>>,
 
     /// The metrics collection maintained by this manager.
     metrics: metrics::Collection,
@@ -231,7 +230,7 @@ impl Manager {
                 continue;
             };
             debug!("Forwarding application command to unit '{unit_name}'");
-            tx.send(data).await.unwrap();
+            tx.send(data).unwrap();
         }
     }
 
@@ -384,15 +383,15 @@ impl Manager {
         spawn_target: SpawnTarget,
     ) where
         SpawnUnit: Fn(Component, Unit),
-        SpawnTarget: Fn(Component, Target, Receiver<TargetCommand>),
+        SpawnTarget: Fn(Component, Target, mpsc::UnboundedReceiver<TargetCommand>),
     {
-        let (zl_tx, zl_rx) = mpsc::channel(10);
-        let (rs_tx, rs_rx) = mpsc::channel(10);
-        let (km_tx, km_rx) = mpsc::channel(10);
-        let (zs_tx, zs_rx) = mpsc::channel(10);
-        let (rs2_tx, rs2_rx) = mpsc::channel(10);
-        let (ps_tx, ps_rx) = mpsc::channel(10);
-        let (http_tx, http_rx) = mpsc::channel(10);
+        let (zl_tx, zl_rx) = mpsc::unbounded_channel();
+        let (rs_tx, rs_rx) = mpsc::unbounded_channel();
+        let (km_tx, km_rx) = mpsc::unbounded_channel();
+        let (zs_tx, zs_rx) = mpsc::unbounded_channel();
+        let (rs2_tx, rs2_rx) = mpsc::unbounded_channel();
+        let (ps_tx, ps_rx) = mpsc::unbounded_channel();
+        let (http_tx, http_rx) = mpsc::unbounded_channel();
 
         self.loader_tx = Some(zl_tx);
         self.review_tx = Some(rs_tx);
@@ -402,7 +401,7 @@ impl Manager {
         self.publish_tx = Some(ps_tx);
         self.http_tx = Some(http_tx);
 
-        let (update_tx, update_rx) = mpsc::channel(10);
+        let (update_tx, update_rx) = mpsc::unbounded_channel();
 
         {
             let name = String::from("CC");
@@ -422,7 +421,7 @@ impl Manager {
             );
 
             info!("Starting target '{name}'");
-            let (cmd_tx, cmd_rx) = mpsc::channel(100);
+            let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
             spawn_target(component, new_target, cmd_rx);
             self.center_tx = Some(cmd_tx);
         }
@@ -613,7 +612,7 @@ impl Manager {
         }
     }
 
-    pub fn terminate(&mut self) {
+    pub async fn terminate(&mut self) {
         let units = [
             ("ZL", self.loader_tx.take().unwrap()),
             ("RS", self.review_tx.take().unwrap()),
@@ -624,18 +623,15 @@ impl Manager {
         ];
         for (name, tx) in units {
             info!("Stopping unit '{name}'");
-            tokio::spawn(async move {
-                let _ = tx.send(ApplicationCommand::Terminate).await;
-                tx.closed().await;
-            });
+            let _ = tx.send(ApplicationCommand::Terminate);
+            tx.closed().await;
         }
 
         {
-            let cmd_tx = Arc::new(self.center_tx.take().unwrap());
-            Self::terminate_target("CC", cmd_tx.clone());
-            while !cmd_tx.is_closed() {
-                std::thread::sleep(Duration::from_millis(10));
-            }
+            info!("Stopping target 'CC'");
+            let tx = self.center_tx.take().unwrap();
+            let _ = tx.send(TargetCommand::Terminate);
+            tx.closed().await;
         }
     }
 
@@ -643,15 +639,12 @@ impl Manager {
         tokio::spawn(new_unit.run(component));
     }
 
-    fn spawn_target(component: Component, new_target: Target, cmd_rx: Receiver<TargetCommand>) {
+    fn spawn_target(
+        component: Component,
+        new_target: Target,
+        cmd_rx: mpsc::UnboundedReceiver<TargetCommand>,
+    ) {
         tokio::spawn(new_target.run(component, cmd_rx));
-    }
-
-    fn terminate_target(name: &str, sender: Arc<Sender<TargetCommand>>) {
-        info!("Stopping target '{name}'");
-        tokio::spawn(async move {
-            let _ = sender.send(TargetCommand::Terminate).await;
-        });
     }
 
     /// Returns a new reference to the manager’s metrics collection.

--- a/src/targets/central_command.rs
+++ b/src/targets/central_command.rs
@@ -14,7 +14,7 @@ use crate::payload::Update;
 #[derive(Debug)]
 pub struct CentralCommandTarget {
     /// A receiver for updates.
-    pub update_rx: mpsc::Receiver<Update>,
+    pub update_rx: mpsc::UnboundedReceiver<Update>,
 
     pub config: Config,
 }
@@ -23,7 +23,7 @@ impl CentralCommandTarget {
     pub async fn run(
         self,
         component: Component,
-        cmd: mpsc::Receiver<TargetCommand>,
+        cmd: mpsc::UnboundedReceiver<TargetCommand>,
     ) -> Result<(), Terminated> {
         CentralCommand::new(self.config, component)
             .run(cmd, self.update_rx)
@@ -48,8 +48,8 @@ impl CentralCommand {
 
     pub async fn run(
         mut self,
-        cmd_rx: mpsc::Receiver<TargetCommand>,
-        update_rx: mpsc::Receiver<Update>,
+        cmd_rx: mpsc::UnboundedReceiver<TargetCommand>,
+        update_rx: mpsc::UnboundedReceiver<Update>,
     ) -> Result<(), Terminated> {
         let _component = &mut self.component;
 
@@ -60,8 +60,8 @@ impl CentralCommand {
 
     pub async fn do_run(
         self: &Arc<Self>,
-        mut cmd_rx: mpsc::Receiver<TargetCommand>,
-        mut update_rx: mpsc::Receiver<Update>,
+        mut cmd_rx: mpsc::UnboundedReceiver<TargetCommand>,
+        mut update_rx: mpsc::UnboundedReceiver<Update>,
     ) -> Result<(), Terminated> {
         loop {
             if let Err(Terminated) = self.process_events(&mut cmd_rx, &mut update_rx).await {
@@ -73,8 +73,8 @@ impl CentralCommand {
 
     pub async fn process_events(
         self: &Arc<Self>,
-        cmd_rx: &mut mpsc::Receiver<TargetCommand>,
-        update_rx: &mut mpsc::Receiver<Update>,
+        cmd_rx: &mut mpsc::UnboundedReceiver<TargetCommand>,
+        update_rx: &mut mpsc::UnboundedReceiver<Update>,
     ) -> Result<(), Terminated> {
         loop {
             tokio::select! {

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -35,7 +35,7 @@ impl Target {
     pub async fn run(
         self,
         component: Component,
-        cmd: mpsc::Receiver<TargetCommand>,
+        cmd: mpsc::UnboundedReceiver<TargetCommand>,
     ) -> Result<(), Terminated> {
         match self {
             Target::CentraLCommand(target) => target.run(component, cmd).await,

--- a/src/units/http_server.rs
+++ b/src/units/http_server.rs
@@ -54,7 +54,7 @@ const HTTP_UNIT_NAME: &str = "HS";
 
 pub struct HttpServer {
     pub listen_addr: SocketAddr,
-    pub cmd_rx: Option<mpsc::Receiver<ApplicationCommand>>,
+    pub cmd_rx: Option<mpsc::UnboundedReceiver<ApplicationCommand>>,
 }
 
 impl HttpServer {

--- a/src/units/key_manager.rs
+++ b/src/units/key_manager.rs
@@ -22,8 +22,8 @@ use tokio::time::MissedTickBehavior;
 pub struct KeyManagerUnit {
     pub dnst_keyset_bin_path: PathBuf,
     pub dnst_keyset_data_dir: PathBuf,
-    pub update_tx: mpsc::Sender<Update>,
-    pub cmd_rx: mpsc::Receiver<ApplicationCommand>,
+    pub update_tx: mpsc::UnboundedSender<Update>,
+    pub cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
 }
 
 impl KeyManagerUnit {
@@ -49,7 +49,7 @@ struct KeyManager {
     component: Component,
     dnst_keyset_bin_path: PathBuf,
     dnst_keyset_data_dir: PathBuf,
-    update_tx: mpsc::Sender<Update>,
+    update_tx: mpsc::UnboundedSender<Update>,
     ks_info: Mutex<HashMap<String, KeySetInfo>>,
 }
 
@@ -58,7 +58,7 @@ impl KeyManager {
         component: Component,
         dnst_keyset_bin_path: PathBuf,
         dnst_keyset_data_dir: PathBuf,
-        update_tx: mpsc::Sender<Update>,
+        update_tx: mpsc::UnboundedSender<Update>,
     ) -> Self {
         Self {
             component,
@@ -71,7 +71,7 @@ impl KeyManager {
 
     async fn run(
         self,
-        cmd_rx: mpsc::Receiver<ApplicationCommand>,
+        cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
     ) -> Result<(), crate::comms::Terminated> {
         let mut interval = tokio::time::interval(Duration::from_secs(5));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -112,7 +112,6 @@ impl KeyManager {
                     .send(Update::ResignZoneEvent {
                         zone_name: zone.apex_name().clone(),
                     })
-                    .await
                     .unwrap();
                 continue;
             }
@@ -163,7 +162,6 @@ impl KeyManager {
                             .send(Update::ResignZoneEvent {
                                 zone_name: zone.apex_name().clone(),
                             })
-                            .await
                             .unwrap();
                         continue;
                     }

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -102,9 +102,9 @@ pub struct ZoneLoader {
     pub tsig_keys: HashMap<String, String>,
 
     /// Updates for the central command.
-    pub update_tx: mpsc::Sender<Update>,
+    pub update_tx: mpsc::UnboundedSender<Update>,
 
-    pub cmd_rx: mpsc::Receiver<ApplicationCommand>,
+    pub cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
 }
 
 impl ZoneLoader {
@@ -204,7 +204,6 @@ impl ZoneLoader {
                             zone_name,
                             zone_serial,
                         })
-                        .await
                         .unwrap();
                 }
 

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -125,9 +125,9 @@ pub struct ZoneServerUnit {
 
     pub source: Source,
 
-    pub update_tx: mpsc::Sender<Update>,
+    pub update_tx: mpsc::UnboundedSender<Update>,
 
-    pub cmd_rx: mpsc::Receiver<ApplicationCommand>,
+    pub cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
 }
 
 impl ZoneServerUnit {
@@ -276,8 +276,8 @@ impl ZoneServer {
     async fn run(
         self,
         unit_name: &str,
-        update_tx: mpsc::Sender<Update>,
-        mut cmd_rx: mpsc::Receiver<ApplicationCommand>,
+        update_tx: mpsc::UnboundedSender<Update>,
+        mut cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
     ) -> Result<(), crate::comms::Terminated> {
         // let status_reporter = self.status_reporter.clone();
 
@@ -328,10 +328,10 @@ impl ZoneServer {
                                 // Approve immediately.
                                 match arc_self.source {
                                     Source::UnsignedZones => {
-                                        update_tx.send(Update::UnsignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).await.unwrap();
+                                        update_tx.send(Update::UnsignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).unwrap();
                                     }
                                     Source::SignedZones => {
-                                        update_tx.send(Update::SignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).await.unwrap();
+                                        update_tx.send(Update::SignedZoneApprovedEvent { zone_name: zone_name.clone(), zone_serial: *zone_serial }).unwrap();
                                     }
                                     Source::PublishedZones => unreachable!(),
                                 }

--- a/src/units/zone_signer.rs
+++ b/src/units/zone_signer.rs
@@ -135,9 +135,9 @@ pub struct ZoneSignerUnit {
 
     pub kmip_server_conn_settings: HashMap<String, KmipServerConnectionSettings>,
 
-    pub update_tx: mpsc::Sender<Update>,
+    pub update_tx: mpsc::UnboundedSender<Update>,
 
-    pub cmd_rx: mpsc::Receiver<ApplicationCommand>,
+    pub cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
 }
 
 #[allow(dead_code)]
@@ -290,7 +290,7 @@ struct ZoneSigner {
     max_concurrent_rrsig_generation_tasks: usize,
     signer_status: Arc<RwLock<ZoneSignerStatus>>,
     treat_single_keys_as_csks: bool,
-    update_tx: mpsc::Sender<Update>,
+    update_tx: mpsc::UnboundedSender<Update>,
     _keys_path: PathBuf,
     kmip_servers: HashMap<String, SyncConnPool>,
 }
@@ -306,7 +306,7 @@ impl ZoneSigner {
         max_concurrent_operations: usize,
         max_concurrent_rrsig_generation_tasks: usize,
         treat_single_keys_as_csks: bool,
-        update_tx: mpsc::Sender<Update>,
+        update_tx: mpsc::UnboundedSender<Update>,
         keys_path: PathBuf,
         kmip_servers: HashMap<String, SyncConnPool>,
     ) -> Self {
@@ -328,7 +328,7 @@ impl ZoneSigner {
 
     async fn run(
         self,
-        mut cmd_rx: mpsc::Receiver<ApplicationCommand>,
+        mut cmd_rx: mpsc::UnboundedReceiver<ApplicationCommand>,
     ) -> Result<(), crate::comms::Terminated> {
         while let Some(cmd) = cmd_rx.recv().await {
             info!("[ZS]: Received command: {cmd:?}");
@@ -714,7 +714,6 @@ impl ZoneSigner {
                 zone_name: zone_name.clone(),
                 zone_serial,
             })
-            .await
             .unwrap();
 
         Ok(())


### PR DESCRIPTION
This helps avoid infecting everything with 'async'.