### PR TITLE
Forward NOTIFYs from the PS to the ZL

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -67,7 +67,10 @@
 
 use domain::base::Serial;
 use domain::zonetree::StoredName;
-use std::fmt::{self, Debug};
+use std::{
+    fmt::{self, Debug},
+    net::IpAddr,
+};
 
 use crate::api::ZoneAdd;
 
@@ -134,6 +137,26 @@ pub enum ApplicationCommand {
         zone_name: StoredName,
         zone_serial: Serial,
     },
+
+    /// Refresh a zone.
+    ///
+    /// The zone loader will initiate a refresh for the zone, and query the
+    /// zone's source to look for a newer version of the zone.  This command
+    /// can be used in response to a user request or a NOTIFY message.
+    RefreshZone {
+        /// The name of the zone to refresh.
+        zone_name: StoredName,
+
+        /// The source address of the NOTIFY message.
+        source: Option<IpAddr>,
+
+        /// The expected new SOA serial for the zone.
+        ///
+        /// If this is set, and the zone's SOA serial is greater than or equal
+        /// to this value, the refresh can be ignored.
+        serial: Option<Serial>,
+    },
+
     SignZone {
         zone_name: StoredName,
         zone_serial: Option<Serial>,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -496,10 +496,6 @@ impl Manager {
             (
                 String::from("ZL"),
                 Unit::ZoneLoader(ZoneLoader {
-                    listen: vec![
-                        "tcp:127.0.0.1:8054".parse().unwrap(),
-                        "udp:127.0.0.1:8054".parse().unwrap(),
-                    ],
                     zones: Arc::new(HashMap::from([(zone_name.clone(), zone_file)])),
                     xfr_in: Arc::new(HashMap::from([(zone_name.clone(), xfr_in)])),
                     xfr_out: Arc::new(HashMap::from([(zone_name.clone(), xfr_out.clone())])),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,11 +1,31 @@
-//------------ Update --------------------------------------------------------
+use std::net::IpAddr;
 
 use domain::base::Serial;
 use domain::zonetree::StoredName;
 
+//------------ Update --------------------------------------------------------
+
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug)]
 pub enum Update {
+    /// A request to refresh a zone.
+    ///
+    /// This is sent by the publication server when it receives an appropriate
+    /// NOTIFY message.
+    RefreshZone {
+        /// The name of the zone to refresh.
+        zone_name: StoredName,
+
+        /// The source address of the NOTIFY message.
+        source: Option<IpAddr>,
+
+        /// The expected new SOA serial for the zone.
+        ///
+        /// If this is set, and the zone's SOA serial is greater than or equal
+        /// to this value, the refresh can be ignored.
+        serial: Option<Serial>,
+    },
+
     UnsignedZoneUpdatedEvent {
         zone_name: StoredName,
         zone_serial: Serial,

--- a/src/targets/central_command.rs
+++ b/src/targets/central_command.rs
@@ -107,6 +107,20 @@ impl CentralCommand {
     async fn direct_update(&self, event: Update) {
         info!("[CC]: Event received: {event:?}");
         let (msg, target, cmd) = match event {
+            Update::RefreshZone {
+                zone_name,
+                source,
+                serial,
+            } => (
+                "Instructing zone loader to refresh the zone",
+                "ZL",
+                ApplicationCommand::RefreshZone {
+                    zone_name,
+                    source,
+                    serial,
+                },
+            ),
+
             Update::UnsignedZoneUpdatedEvent {
                 zone_name,
                 zone_serial,

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -29,7 +29,7 @@ use domain::net::server::message::Request;
 use domain::net::server::middleware::cookies::CookiesMiddlewareSvc;
 use domain::net::server::middleware::edns::EdnsMiddlewareSvc;
 use domain::net::server::middleware::mandatory::MandatoryMiddlewareSvc;
-use domain::net::server::middleware::notify::NotifyMiddlewareSvc;
+use domain::net::server::middleware::notify::{Notifiable, NotifyMiddlewareSvc};
 use domain::net::server::middleware::tsig::TsigMiddlewareSvc;
 use domain::net::server::middleware::xfr::XfrMiddlewareSvc;
 use domain::net::server::service::{CallResult, Service, ServiceError, ServiceResult};
@@ -85,9 +85,6 @@ use crate::zonemaintenance::types::{
 
 #[derive(Debug)]
 pub struct ZoneLoader {
-    /// Addresses and protocols to listen on.
-    pub listen: Vec<ListenAddr>,
-
     /// The zone names and (if primary) corresponding zone file paths to load.
     pub zones: Arc<HashMap<String, String>>,
 
@@ -163,26 +160,6 @@ impl ZoneLoader {
             }
         }
 
-        // Define a server to handle NOTIFY messages and notify the
-        // ZoneMaintainer on receipt, thereby triggering it to fetch the
-        // latest version of the updated zone.
-        let svc = service_fn(my_noop_service, ());
-        let svc = NotifyMiddlewareSvc::new(svc, zone_maintainer.clone());
-        let svc = CookiesMiddlewareSvc::with_random_secret(svc);
-        let svc = EdnsMiddlewareSvc::new(svc);
-        let svc = MandatoryMiddlewareSvc::new(svc);
-        let svc = Arc::new(svc);
-
-        for addr in self.listen.iter().cloned() {
-            info!("[ZL]: Binding on {addr:?}");
-            let svc = svc.clone();
-            tokio::spawn(async move {
-                if let Err(err) = Self::server(addr, svc).await {
-                    error!("[ZL]: {err}");
-                }
-            });
-        }
-
         let zone_maintainer_clone = zone_maintainer.clone();
         tokio::spawn(async move { zone_maintainer_clone.run().await });
 
@@ -207,59 +184,67 @@ impl ZoneLoader {
                 }
 
                 cmd = self.cmd_rx.recv() => {
+                    info!(
+                        "[ZL] Received command: {cmd:?}",
+                    );
+
                     match cmd {
-                        Some(cmd) => {
-                            info!(
-                                "[ZL] Received command: {cmd:?}",
-                            );
-
-                            match cmd {
-                                ApplicationCommand::Terminate => {
-                                    // arc_self.status_reporter.terminated();
-                                    return Err(Terminated);
-                                }
-                                ApplicationCommand::RegisterZone { register } => {
-                                    let res = match register.source {
-                                        ZoneSource::Zonefile { path /* Lacks XFR out settings */ } => {
-                                            Self::register_primary_zone(
-                                                register.name.clone(),
-                                                &path.to_string(),
-                                                component.tsig_key_store(),
-                                                "",
-                                                &zone_updated_tx,
-                                              ).await
-                                        }
-                                        ZoneSource::Server { addr /* Lacks TSIG key name */ } => {
-                                            let xfr_in = format!("{addr}");
-                                            Self::register_secondary_zone(
-                                                register.name.clone(),
-                                                component.tsig_key_store(),
-                                                &xfr_in,
-                                                zone_updated_tx.clone(),
-                                            )
-                                        },
-                                    };
-
-                                    match res {
-                                        Err(_) => {
-                                            error!("[ZL]: Error: Failed to register zone '{}'", register.name);
-                                        }
-
-                                        Ok(zone) => {
-                                            if let Err(err) = zone_maintainer.insert_zone(zone).await {
-                                                error!("[ZL]: Error: Failed to insert zone '{}': {err}", register.name);
-                                            }
-                                        }
-                                    }
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-
-                        None => {
+                        Some(ApplicationCommand::Terminate) | None => {
                             // arc_self.status_reporter.terminated();
                             return Err(Terminated);
                         }
+
+                        Some(ApplicationCommand::RegisterZone { register }) => {
+                            let res = match register.source {
+                                ZoneSource::Zonefile { path /* Lacks XFR out settings */ } => {
+                                    Self::register_primary_zone(
+                                        register.name.clone(),
+                                        &path.to_string(),
+                                        component.tsig_key_store(),
+                                        "",
+                                        &zone_updated_tx,
+                                      ).await
+                                }
+                                ZoneSource::Server { addr /* Lacks TSIG key name */ } => {
+                                    let xfr_in = format!("{addr}");
+                                    Self::register_secondary_zone(
+                                        register.name.clone(),
+                                        component.tsig_key_store(),
+                                        &xfr_in,
+                                        zone_updated_tx.clone(),
+                                    )
+                                },
+                            };
+
+                            match res {
+                                Err(_) => {
+                                    error!("[ZL]: Error: Failed to register zone '{}'", register.name);
+                                }
+
+                                Ok(zone) => {
+                                    if let Err(err) = zone_maintainer.insert_zone(zone).await {
+                                        error!("[ZL]: Error: Failed to insert zone '{}': {err}", register.name);
+                                    }
+                                }
+                            }
+                        }
+
+                        Some(ApplicationCommand::RefreshZone {
+                            zone_name,
+                            serial,
+                            source,
+                        }) => {
+                            if let Some(source) = source {
+                                let _ = zone_maintainer.notify_zone_changed(Class::IN, &zone_name, serial, source).await;
+                            } else {
+                                // TODO: Should we check the serial number here?
+                                let _ = serial;
+
+                                zone_maintainer.force_zone_refresh(&zone_name, Class::IN).await;
+                            }
+                        }
+
+                        Some(_) => {}
                     }
                 }
             }
@@ -374,45 +359,6 @@ impl ZoneLoader {
 
         Ok(zone_cfg)
     }
-
-    async fn server<Svc>(addr: ListenAddr, svc: Svc) -> Result<(), std::io::Error>
-    where
-        Svc: Service<Vec<u8>, ()> + Clone,
-    {
-        let buf = VecBufSource;
-        match addr {
-            ListenAddr::Udp(addr) => {
-                let sock = UdpSocket::bind(addr).await?;
-                let config = dgram::Config::new();
-                let srv = DgramServer::with_config(sock, buf, svc, config);
-                let srv = Arc::new(srv);
-                srv.run().await;
-            }
-            ListenAddr::Tcp(addr) => {
-                let sock = tokio::net::TcpListener::bind(addr).await?;
-                let mut conn_config = ConnectionConfig::new();
-                conn_config.set_max_queued_responses(10000);
-                let mut config = stream::Config::new();
-                config.set_connection_config(conn_config);
-                let srv = StreamServer::with_config(sock, buf, svc, config);
-                let srv = Arc::new(srv);
-                srv.run().await;
-            } // #[cfg(feature = "tls")]
-              // ListenAddr::Tls(addr, config) => {
-              //     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
-              //     let sock = TcpListener::bind(addr).await?;
-              //     let sock = tls::RustlsTcpListener::new(sock, acceptor);
-              //     let mut conn_config = ConnectionConfig::new();
-              //     conn_config.set_max_queued_responses(10000);
-              //     let mut config = stream::Config::new();
-              //     config.set_connection_config(conn_config);
-              //     let srv = StreamServer::with_config(sock, buf, svc, config);
-              //     let srv = Arc::new(srv);
-              //     srv.run().await;
-              // }
-        }
-        Ok(())
-    }
 }
 
 async fn get_zone_serial(apex_name: Name<Bytes>, zone: &Zone) -> Option<Serial> {
@@ -463,10 +409,6 @@ async fn load_file_into_zone(zone_name: &String, zone_path: &str) -> Result<Zone
         before.elapsed().as_secs()
     );
     Ok(zone)
-}
-
-fn my_noop_service(_request: Request<Vec<u8>, ()>, _meta: ()) -> ServiceResult<Vec<u8>> {
-    Err(ServiceError::Refused)
 }
 
 //------------- NotifyOnWriteZone --------------------------------------------

--- a/src/zonemaintenance/maintainer.rs
+++ b/src/zonemaintenance/maintainer.rs
@@ -570,7 +570,6 @@ where
         rx.await.map_err(|_| ZoneMaintainerError::UnknownZone)
     }
 
-    #[allow(dead_code)]
     pub async fn force_zone_refresh(&self, apex_name: &StoredName, class: Class) {
         self.event_tx
             .send(Event::ZoneRefreshRequested {


### PR DESCRIPTION
This removes the zone loader's NOTIFY support in favor of listening through the publication server.  This means users can use the same port for getting published zones and pinging the server for updated zones.

At the moment, SOA serials are not checked, and requests for arbitrary zones are forwarded.  At some point, we should update the NOTIFY middleware service to pass SOA serials forward, and should only forward zones known to the zone loader.  The latter point can be a bit difficult because we can't check the `ZoneTree`; it only contains zones that have been loaded already, and we might want to allow NOTIFY-ing for a zone that was not successfully loaded yet.  The upcoming state work will make this possible.