### PR TITLE
Use RFC 1996 NOTIFY serial now that domain exposes it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain?branch=patches-for-nameshed-prototype#ab61e4c9c51d38d3574c232040849bd0ef0d2923"
+source = "git+https://github.com/NLnetLabs/domain?branch=patches-for-nameshed-prototype#7268eb36b850959b67f52d94940462181f4b3fd7"
 dependencies = [
  "arc-swap",
  "bcder",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "domain-macros"
 version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain?branch=patches-for-nameshed-prototype#ab61e4c9c51d38d3574c232040849bd0ef0d2923"
+source = "git+https://github.com/NLnetLabs/domain?branch=patches-for-nameshed-prototype#7268eb36b850959b67f52d94940462181f4b3fd7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -439,6 +439,7 @@ impl Notifiable for XfrDataProvidingZonesWrapper {
         &self,
         _class: Class,
         _apex_name: &Name<Bytes>,
+        _serial: Option<Serial>,
         _source: IpAddr,
     ) -> Pin<
         Box<

--- a/src/zonemaintenance/maintainer.rs
+++ b/src/zonemaintenance/maintainer.rs
@@ -1974,6 +1974,7 @@ where
         &self,
         class: Class,
         apex_name: &StoredName,
+        serial: Option<Serial>,
         source: IpAddr,
     ) -> Pin<Box<dyn Future<Output = Result<(), NotifyError>> + Sync + Send + '_>> {
         let apex_name = apex_name.clone();
@@ -1982,7 +1983,34 @@ where
                 return Err(NotifyError::Other);
             }
 
-            if self.zones().get_zone(&apex_name, class).is_none() {
+            if let Some(zone) = self.zones().get_zone(&apex_name, class) {
+                // https://www.rfc-editor.org/rfc/rfc1996#section-3
+                //   "3.7. A NOTIFY request has QDCOUNT>0, ANCOUNT>=0, AUCOUNT>=0,
+                //   ADCOUNT>=0.  If ANCOUNT>0, then the answer section
+                //   represents an unsecure hint at the new RRset for this
+                //   <QNAME,QCLASS,QTYPE>.  A slave receiving such a hint is free
+                //   to treat equivilence of this answer section with its local
+                //   data as a "no further work needs to be done" indication.  If
+                //   ANCOUNT=0, or ANCOUNT>0 and the answer section differs from
+                //   the slave's local data, then the slave should query its known
+                //   masters to retrieve the new data."
+                if let Some(serial) = serial {
+                    let answer = zone.read().query(zone.apex_name().clone(), Rtype::SOA)
+                         .inspect_err(|_| warn!("[ZM]: Unable to read SOA for zone '{apex_name}' when checking if notify serial hint is newer: Out of zone error"))
+                         .map_err(|_| NotifyError::Other)?;
+                    if let AnswerContent::Data(rrset) = answer.content() {
+                        if let ZoneRecordData::Soa(soa) = rrset.first().unwrap().data() {
+                            if soa.serial() > serial {
+                                debug!(
+                                    "[ZM]: Ignoring outdated serial ({serial} < {}) received for zone '{apex_name}' from {source}",
+                                    soa.serial()
+                                );
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            } else {
                 let zone_id = ZoneId::new(apex_name.clone(), class);
                 if !self.pending_zones.read().await.contains_key(&zone_id) {
                     return Err(NotifyError::NotAuthForZone);
@@ -2033,10 +2061,8 @@ where
             self.event_tx
                 .send(Event::ZoneChanged(msg))
                 .await
-                .map_err(|err| {
-                    error!("Internal error: {err}");
-                    NotifyError::Other
-                })?;
+                .inspect_err(|err| warn!("[ZM]: Unable to send zone changed event for zone '{apex_name}' due to a zone changed notification: {err}"))
+                .map_err(|_| NotifyError::Other)?;
 
             Ok(())
         })


### PR DESCRIPTION
Updates domain and fixes it to compile after the breaking change that was introduced regarding also passing the serial to the notify handler. Use that serial to avoid scheduling a zone refresh check if the given serial is older than the one currently in the zone.