### PR TITLE
Update env var handling.

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -4,6 +4,7 @@ use arc_swap::ArcSwap;
 use log::{debug, info};
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
@@ -19,7 +20,7 @@ use crate::units::zone_loader::ZoneLoader;
 use crate::units::zone_server::{self, ZoneServerUnit};
 use crate::units::zone_signer::{KmipServerConnectionSettings, TomlDenialConfig, ZoneSignerUnit};
 use crate::units::Unit;
-use domain::zonetree::ZoneTree;
+use domain::zonetree::{StoredName, ZoneTree};
 
 //------------ Component -----------------------------------------------------
 
@@ -449,7 +450,10 @@ impl Manager {
             }
         }
 
-        let zone_name = std::env::var("ZL_IN_ZONE").unwrap_or("example.com.".into());
+        let zone_name = StoredName::from_str(
+            &std::env::var("ZL_IN_ZONE").unwrap_or("example.com.".to_string()),
+        )
+        .unwrap();
         let xfr_in = std::env::var("ZL_XFR_IN").unwrap_or("127.0.0.1:8055 KEY sec1-key".into());
         let xfr_out = std::env::var("PS_XFR_OUT").unwrap_or("127.0.0.1:8055 KEY sec1-key".into());
         let tsig_key_name = std::env::var("ZL_TSIG_KEY_NAME").unwrap_or("sec1-key".into());

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -449,42 +449,6 @@ impl Manager {
             }
         }
 
-        let client_cert_path = std::env::var("PYKMIP_CLIENT_CERT_PATH").ok();
-        let client_key_path = std::env::var("PYKMIP_CLIENT_KEY_PATH").ok();
-
-        if client_cert_path.is_some() && client_key_path.is_some() {
-            kmip_server_conn_settings.insert(
-                "pykmip".to_string(),
-                KmipServerConnectionSettings {
-                    server_addr: "127.0.0.1".into(),
-                    server_port: 5696,
-                    server_insecure: true,
-                    client_cert_path: Some(
-                        "/home/ximon/docker_data/pykmip/pykmip-data/selfsigned.crt".into(),
-                    ),
-                    client_key_path: Some(
-                        "/home/ximon/docker_data/pykmip/pykmip-data/selfsigned.key".into(),
-                    ),
-                    ..Default::default()
-                },
-            );
-        }
-
-        let server_username = std::env::var("FORTANIX_USER").ok();
-        let server_password = std::env::var("FORTANIX_PASS").ok();
-        if server_username.is_some() && server_password.is_some() {
-            kmip_server_conn_settings.insert(
-                "fortanix".to_string(),
-                KmipServerConnectionSettings {
-                    server_addr: "eu.smartkey.io".into(),
-                    server_insecure: true,
-                    server_username,
-                    server_password,
-                    ..Default::default()
-                },
-            );
-        }
-
         let zone_name = std::env::var("ZL_IN_ZONE").unwrap_or("example.com.".into());
         let zone_file = std::env::var("ZL_IN_ZONE_FILE").unwrap_or("".into());
         let xfr_in = std::env::var("ZL_XFR_IN").unwrap_or("127.0.0.1:8055 KEY sec1-key".into());

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -450,7 +450,6 @@ impl Manager {
         }
 
         let zone_name = std::env::var("ZL_IN_ZONE").unwrap_or("example.com.".into());
-        let zone_file = std::env::var("ZL_IN_ZONE_FILE").unwrap_or("".into());
         let xfr_in = std::env::var("ZL_XFR_IN").unwrap_or("127.0.0.1:8055 KEY sec1-key".into());
         let xfr_out = std::env::var("PS_XFR_OUT").unwrap_or("127.0.0.1:8055 KEY sec1-key".into());
         let tsig_key_name = std::env::var("ZL_TSIG_KEY_NAME").unwrap_or("sec1-key".into());
@@ -465,7 +464,7 @@ impl Manager {
                         "tcp:127.0.0.1:8054".parse().unwrap(),
                         "udp:127.0.0.1:8054".parse().unwrap(),
                     ],
-                    zones: Arc::new(HashMap::from([(zone_name.clone(), zone_file)])),
+                    zones: Default::default(),
                     xfr_in: Arc::new(HashMap::from([(zone_name.clone(), xfr_in)])),
                     xfr_out: Arc::new(HashMap::from([(zone_name.clone(), xfr_out.clone())])),
                     tsig_keys: HashMap::from([(tsig_key_name, tsig_key)]),
@@ -480,7 +479,7 @@ impl Manager {
                         "tcp:127.0.0.1:8056".parse().unwrap(),
                         "udp:127.0.0.1:8056".parse().unwrap(),
                     ],
-                    xfr_out: HashMap::from([(zone_name, xfr_out)]),
+                    xfr_out: HashMap::from([(zone_name.clone(), xfr_out)]),
                     // Temporarily disable hooks as the required HTTP functionality has been removed pending replacement.
                     hooks: vec![], // vec![String::from("/tmp/approve_or_deny.sh")],
                     mode: zone_server::Mode::Prepublish,
@@ -522,7 +521,7 @@ impl Manager {
                         "udp:127.0.0.1:8057".parse().unwrap(),
                     ],
                     xfr_out: HashMap::from([(
-                        "example.com".into(),
+                        zone_name.clone(),
                         "127.0.0.1:8055 KEY sec1-key".into(),
                     )]),
                     // Temporarily disable hooks as the required HTTP functionality has been removed pending replacement.
@@ -540,7 +539,7 @@ impl Manager {
                         "tcp:127.0.0.1:8058".parse().unwrap(),
                         "udp:127.0.0.1:8058".parse().unwrap(),
                     ],
-                    xfr_out: HashMap::from([("example.com".into(), "127.0.0.1:8055".into())]),
+                    xfr_out: HashMap::from([(zone_name.into(), "127.0.0.1:8055".into())]),
                     hooks: vec![],
                     mode: zone_server::Mode::Publish,
                     source: zone_server::Source::PublishedZones,

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -189,28 +189,28 @@ impl ZoneLoader {
 
                         Some(ApplicationCommand::RegisterZone { register }) => {
                             let res = match register.source {
-                                        ZoneSource::Zonefile { path /* Lacks XFR out settings */ } => {
-                                            Self::register_primary_zone(
-                                                register.name.clone(),
-                                                &path.to_string(),
-                                                component.tsig_key_store(),
-                                                None,
-                                                &self.xfr_out,
-                                                &zone_updated_tx,
-                                              ).await
-                                        }
-                                        ZoneSource::Server { addr /* Lacks TSIG key name */ } => {
-                                            // Use any existing XFR inbound
-                                            // ACL that has been defined for
-                                            // this zone from this source.
-                                            Self::register_secondary_zone(
-                                                register.name.clone(),
-                                                component.tsig_key_store(),
-                                                Some(addr),
-                                                &self.xfr_in,
-                                                zone_updated_tx.clone(),
-                                            )
-                                        },
+                                ZoneSource::Zonefile { path /* Lacks XFR out settings */ } => {
+                                    Self::register_primary_zone(
+                                        register.name.clone(),
+                                        &path.to_string(),
+                                        component.tsig_key_store(),
+                                        None,
+                                        &self.xfr_out,
+                                        &zone_updated_tx,
+                                      ).await
+                                }
+                                ZoneSource::Server { addr /* Lacks TSIG key name */ } => {
+                                    // Use any existing XFR inbound ACL that
+                                    // has been defined for this zone from
+                                    // this source.
+                                    Self::register_secondary_zone(
+                                        register.name.clone(),
+                                        component.tsig_key_store(),
+                                        Some(addr),
+                                        &self.xfr_in,
+                                        zone_updated_tx.clone(),
+                                    )
+                                },
                             };
 
                             match res {

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -131,8 +131,6 @@ impl ZoneLoader {
         // Load primary zones.
         // Create secondary zones.
         for (zone_name, zone_path) in self.zones.iter() {
-            error!("[ZL]: Error: Zone name '{zone_name}' is invalid. Skipping zone.");
-
             let zone = if !zone_path.is_empty() {
                 Self::register_primary_zone(
                     zone_name.clone(),

--- a/src/units/zone_loader.rs
+++ b/src/units/zone_loader.rs
@@ -230,11 +230,6 @@ impl ZoneLoader {
                                             // Use any existing XFR inbound
                                             // ACL that has been defined for
                                             // this zone from this source.
-                                            let xfr_in = self.xfr_in
-                                                .get(&register.name)
-                                                .map(|v| v.to_string())
-                                                .unwrap_or_default();
-                                            error!("XIMON: {xfr_in}");
                                             Self::register_secondary_zone(
                                                 register.name.clone(),
                                                 component.tsig_key_store(),

--- a/src/units/zone_server.rs
+++ b/src/units/zone_server.rs
@@ -117,7 +117,7 @@ pub struct ZoneServerUnit {
     pub listen: Vec<ListenAddr>,
 
     /// XFR out per zone: Allow XFR to, and when with a port also send NOTIFY to.
-    pub xfr_out: HashMap<String, String>,
+    pub xfr_out: HashMap<StoredName, String>,
 
     pub hooks: Vec<String>,
 

--- a/src/zonemaintenance/types.rs
+++ b/src/zonemaintenance/types.rs
@@ -147,7 +147,6 @@ impl<T: Clone + Debug + Default> SrcDstConfig<T> {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 pub enum XfrStrategy {
     /// Do not support XFR at all.
-    #[default]
     None,
 
     /// Support only AXFR.
@@ -160,6 +159,7 @@ pub enum XfrStrategy {
     ///
     /// If IXFR cannot be provided due to missing required incremental
     /// difference data, fallback to full AXFR instead.
+    #[default]
     IxfrWithAxfrFallback,
 }
 


### PR DESCRIPTION
Remove obsoleted env var handling, and fix XFR/NOTIFY configuration.

- Use zone names as HashMap keys because they will match both "example.com" and "example.com." while string matching will not, and because the only way to add zones now is from the CLI which sends a validated zone name.
- If XFR/NOTIFY settings exist for the zone being added _for the same source_, use them, but if the source is different then use default settings.
- Make logging for primary and secondary configuration consistent.
- Change the default mode of XFR from None to IXFR with AXFR fallback, as if a primary is added we probably want to serve XFR by default to secondaries.

With this change a zone is not always added, you must now use the CLI to add a zone. You can still however preconfigure via env vars XFR / NOTIFY settings, because the CLI doesn't support that yet. Preconfigured settings will be used if they match the zone being added by zone name and source address, otherwise defaults will be used.